### PR TITLE
IMM overtaking control fix

### DIFF
--- a/ipmi_fancontrol-ng
+++ b/ipmi_fancontrol-ng
@@ -43,7 +43,7 @@ $hostname =~ s/\n//g;
 #my $number_of_fanbanks  = 1; # Number of BANKs of FANs to update
 my $number_of_fanbanks  = 2; # Number of BANKs of FANs to update
 my $min_temp_change     = 0; # *C minimum change to actually cause a fan speed update
-my $seconds_to_sleep    = 5; # Number of seconds to sleep between update loops
+my $seconds_to_sleep    = 0; # Number of seconds to sleep between update loops
 
 # IPMI Configuration
 #my $ipmi_username       = "username_goes_here";

--- a/ipmi_fancontrol-ng
+++ b/ipmi_fancontrol-ng
@@ -93,7 +93,6 @@ sub SetFanSpeed
 
     my $cpu_temp_difference = $g_current_cpu_temp - $g_last_set_cpu_temp;
     my $gpu_temp_difference = $g_current_gpu_temp - $g_last_set_gpu_temp;
-    if( ( (abs $cpu_temp_difference) > $min_temp_change ) or ( (abs $gpu_temp_difference) > $min_temp_change ) )
     {
         # Set all 4 fan banks to operate at $fan_speed duty cycle (0x0-0x64 valid range)
         print "\n";


### PR DESCRIPTION
Remove the check for temperature change on CPU sensors. Script now force applies fan speed at every loop. This (seemingly) stops the IMM from ramping up the fans for a few seconds on the temperature change.  

Still in testing on my x3650 M5 but looks good so far. 